### PR TITLE
Fix a bug that will corrupt plain data

### DIFF
--- a/CEX Library/CEXEngine/Crypto/Processing/CipherStream.cs
+++ b/CEX Library/CEXEngine/Crypto/Processing/CipherStream.cs
@@ -705,7 +705,7 @@ namespace VTDev.Libraries.CEXEngine.Crypto.Processing
         {
 	        int blkSize = m_cipherEngine.BlockSize;
 	        long inpSize = (InStream.Length - InStream.Position);
-	        long alnSize = (inpSize < blkSize) ? 0 : inpSize - blkSize;
+	        long alnSize = (inpSize / blkSize) * blkSize;
 	        long count = 0;
 	        byte[] inpBuffer = new byte[blkSize];
 	        byte[] outBuffer = new byte[blkSize];
@@ -738,7 +738,7 @@ namespace VTDev.Libraries.CEXEngine.Crypto.Processing
         {
 	        int blkSize = m_cipherEngine.BlockSize;
 	        long inpSize = (Input.Length - InOffset);
-	        long alnSize = (inpSize < blkSize) ? 0 : inpSize - blkSize;
+	        long alnSize = (inpSize / blkSize) * blkSize;
 	        long count = 0;
 
 	        m_cipherEngine.IsParallel = false;


### PR DESCRIPTION
Although this repo is inactive, this bug will cause data corruption in this case: The plain data length is 16 aligned already, and the plain data's last byte is 0-15. In this case, the code will go into `alnSize != inpSize` and cut off some padding by reading last byte, even the data is already 16 aligned and does not need such trim.